### PR TITLE
Updating conduit and resourcet upper bounds

### DIFF
--- a/lzma-conduit.cabal
+++ b/lzma-conduit.cabal
@@ -1,5 +1,5 @@
 name:                lzma-conduit
-version:             1.0.8
+version:             1.1.0
 synopsis:            Conduit interface for lzma/xz compression.
 description:
   High level bindings to xz-utils.
@@ -30,8 +30,8 @@ library
     base              >= 3      && < 5,
     bindings-DSL      >= 1.0    && < 1.1,
     bytestring        >= 0.9.1  && < 0.11,
-    conduit           >= 0.4    && < 1.1,
-    resourcet         >= 0.3    && < 0.5,
+    conduit           >= 0.4    && < 1.2,
+    resourcet         >= 0.3    && < 1.2,
     transformers      >= 0.2    && < 0.4
   ghc-options:
     -Wall
@@ -56,6 +56,7 @@ test-suite lzma-test
     base                       >= 3      && < 5,
     bytestring,
     conduit,
+    resourcet,
     test-framework,
     test-framework-hunit,
     test-framework-quickcheck2,


### PR DESCRIPTION
Updates `conduit` and `resourcet` upper bounds to a new, safe, maximum of `1.2`.

Despite the API of `conduit >= 1.1` in particular containing a number of breaking changes - none of the internals of this library needed to be updated.

The tests pass with the introduction of `resourcet`, as `Data.Conduit` no longer exports `runResourceT`.

The version number of this library has also been bumped to `1.1.0`.
