### PR TITLE
transformers: compiles with 0.5.x

### DIFF
--- a/lzma-conduit.cabal
+++ b/lzma-conduit.cabal
@@ -33,7 +33,7 @@ library
     bytestring        >= 0.9.1  && < 0.11,
     conduit           >= 0.4    && < 1.3,
     resourcet         >= 0.3    && < 1.2,
-    transformers      >= 0.2    && < 0.5
+    transformers      >= 0.2    && < 0.6
   ghc-options:
     -Wall
   includes:


### PR DESCRIPTION
In general, I'd avoid setting version upper bounds and let it break when it does. But here's the minimal change for TLS 7.8