### PR TITLE
Permit conduit-1.3.0 and resourcet-1.2.0

### DIFF
--- a/lzma-conduit.cabal
+++ b/lzma-conduit.cabal
@@ -1,6 +1,6 @@
 cabal-version:       1.12
 name:                lzma-conduit
-version:             1.2.0
+version:             1.2.1
 synopsis:            Conduit interface for lzma/xz compression.
 description:
   This package provides an Conduit interface for the LZMA compression algorithm used in the .xz file format.
@@ -29,9 +29,9 @@ library
   build-depends:
     base              >= 4.5    && < 5,
     bytestring        >= 0.9.1  && < 0.11,
-    conduit           >= 1.0    && < 1.3,
+    conduit           >= 1.0    && < 1.4,
     lzma              >= 0.0.0.3 && < 0.1,
-    resourcet         >= 0.4    && < 1.2,
+    resourcet         >= 1.1.0  && < 1.3,
     transformers      >= 0.2    && < 0.6
   ghc-options:
     -Wall

--- a/lzma-conduit.cabal
+++ b/lzma-conduit.cabal
@@ -29,7 +29,7 @@ library
   build-depends:
     base              >= 4.5    && < 5,
     bytestring        >= 0.9.1  && < 0.11,
-    conduit           >= 1.0    && < 1.4,
+    conduit           >= 1.1.0  && < 1.4,
     lzma              >= 0.0.0.3 && < 0.1,
     resourcet         >= 1.1.0  && < 1.3,
     transformers      >= 0.2    && < 0.6
@@ -63,4 +63,3 @@ test-suite lzma-test
 source-repository head
   type:     git
   location: https://github.com/alphaHeavy/lzma-conduit.git
-


### PR DESCRIPTION
Recently conduit-1.3.0 was released, see:
https://hackage.haskell.org/package/conduit-1.3.0
Also, resourcet-1.2.0 was released, see:
https://hackage.haskell.org/package/resourcet-1.2.0

Changelogs:
• https://hackage.haskell.org/package/conduit-1.3.0/changelog
• https://hackage.haskell.org/package/resourcet-1.2.0/changelog

I had to increase lower bound on `resourcet` because latest version
doesn't export `monadThrow` function anymore. I can try to find a way
to still support `resourcet-0.4` if it's necessary.

`Conduit` alias is not used anymore, because it's deprecated.